### PR TITLE
[delete] global variable in autoload dir

### DIFF
--- a/autoload/commentblock.vim
+++ b/autoload/commentblock.vim
@@ -1,10 +1,5 @@
 scriptencoding utf-8
 
-if !exists('g:loaded_commentblock')
-  finish
-endif
-let g:loaded_commentblock = 1
-
 let s:save_cpo = &cpo
 set cpo&vim
 


### PR DESCRIPTION
Hello, maintainer.
Thanks for creating great Vim plugin.
I think `let g:loaded_commentblock = 1` don't need in autoload dir so I delete it.
Could you check this PR?